### PR TITLE
Fix bad extractions in figures with captions to the side

### DIFF
--- a/src/main/scala/org/allenai/pdffigures2/FigureDetector.scala
+++ b/src/main/scala/org/allenai/pdffigures2/FigureDetector.scala
@@ -417,7 +417,7 @@ object FigureDetector {
           nonFigureContent, bounds
         ).copy(x2 = captBox.x1)
         if (twoColumn) {
-          val containsCenterElement = !crossesCenter.exists(prop.contains(_, 2))
+          val containsCenterElement = crossesCenter.exists(prop.contains(_, 2))
           if (containsCenterElement ||
             !(prop.x1 < pageCenter.get && prop.x2 > pageCenter.get)) {
             proposals = Proposal(prop, caption, ProposalDirection.Left) :: proposals
@@ -432,7 +432,7 @@ object FigureDetector {
           nonFigureContent, bounds
         ).copy(x1 = captBox.x2)
         if (twoColumn) {
-          val containsCenterElement = !crossesCenter.exists(prop.contains(_, 2))
+          val containsCenterElement = crossesCenter.exists(prop.contains(_, 2))
           if (containsCenterElement ||
             !(prop.x1 < pageCenter.get && prop.x2 > pageCenter.get)) {
             proposals = Proposal(prop, caption, ProposalDirection.Right) :: proposals


### PR DESCRIPTION
Currently, figure extraction is failing on certain figures with captions to the side, for example:

https://www.semanticscholar.org/paper/A-Biophysically-Detailed-Model-of-Neocortical-Reimann-Anastassiou/0239734a585976f3ed8571151b7ac08f1f9363f3

The cause seems to be that the left and right proposals are not added to the list of candidate proposals. Right now, “containsCenterElement” is true iff the proposal *doesn’t* contain a figure element that crosses the center of the page. As written the second disjunct on 421-422 is vacuous, because if the proposal box fully contains any region spanning the center (making first disjunct false), then the proposal box necessarily also spans the center (making the second disjunct false).

Removing the negation fixes the extraction errors for the above pdf. Was the intention of the if statement to ensure that if the proposal crosses the center, then it must contain a figure element that crosses the center? Evaluation for this change shows no difference on the conference dataset and four improvements on the s2 dataset.

With Fix: `Precision: 0.943, Recall: 0.908, F1: 0.925`

Original: `Precision: 0.941, Recall: 0.905, F1: 0.923`

    Evaluations shared 345 docs (345 in eval1, 345 in eval2)
    29056412043ac1eca1e926f3354c86fefc462372: F2 p=4 E1=correct, E2=wrong_region_box
    29056412043ac1eca1e926f3354c86fefc462372: F3 p=4 E1=correct, E2=wrong_region_box
    6612497a240be203d93cfafa9f3c9db7fdecc120: F1 p=4 E1=correct, E2=wrong_region_box
    8261318d3c52ffe539e431b353600ac92abe4e67: F4 p=4 E1=correct, E2=right_caption_no_region
    Total of 4 differences