### PR TITLE
Flood fill memory fix

### DIFF
--- a/src/main/java/org/allenai/pdffigures2/RegexWithTimeout.java
+++ b/src/main/java/org/allenai/pdffigures2/RegexWithTimeout.java
@@ -1,0 +1,45 @@
+package org.allenai.pdffigures2;
+
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class RegexWithTimeout {
+  public static class RegexTimeout extends RuntimeException { }
+
+  public static Matcher matcher(final Pattern pattern, final CharSequence string) {
+    final long timeout = 1500; //ms
+
+    class TimeoutCharSequence implements CharSequence {
+      private CharSequence inner;
+      private long abortTime;
+
+      public TimeoutCharSequence(final CharSequence inner, final long abortTime) {
+        super();
+        this.inner = inner;
+        this.abortTime = abortTime;
+      }
+
+      public char charAt(int index) {
+        if(System.currentTimeMillis() >= abortTime)
+          throw new RegexTimeout();
+
+        return inner.charAt(index);
+      }
+
+      public int length() {
+        return inner.length();
+      }
+
+      public CharSequence subSequence(int start, int end) {
+        return new TimeoutCharSequence(inner.subSequence(start, end), abortTime);
+      }
+
+      public String toString() {
+        return inner.toString();
+      }
+    }
+
+    return pattern.matcher(new TimeoutCharSequence(string, System.currentTimeMillis() + timeout));
+  }
+}

--- a/src/main/scala/org/allenai/pdffigures2/FigureExtractorBatchCli.scala
+++ b/src/main/scala/org/allenai/pdffigures2/FigureExtractorBatchCli.scala
@@ -138,7 +138,7 @@ object FigureExtractorBatchCli extends Logging {
   ): Either[ProcessingError, ProcessingStatistics] = {
     val fileStartTime = System.nanoTime()
     var doc: PDDocument = null
-    val figureExtractor = FigureExtractor(true, true, true, true, true)
+    val figureExtractor = FigureExtractor()
     try {
       doc = PDDocument.load(inputFile)
       val useCairo = FigureRenderer.CairoFormat.contains(config.figureFormat)

--- a/src/main/scala/org/allenai/pdffigures2/FigureExtractorBatchCli.scala
+++ b/src/main/scala/org/allenai/pdffigures2/FigureExtractorBatchCli.scala
@@ -138,7 +138,7 @@ object FigureExtractorBatchCli extends Logging {
   ): Either[ProcessingError, ProcessingStatistics] = {
     val fileStartTime = System.nanoTime()
     var doc: PDDocument = null
-    val figureExtractor = FigureExtractor()
+    val figureExtractor = FigureExtractor(true, true, true, true, true)
     try {
       doc = PDDocument.load(inputFile)
       val useCairo = FigureRenderer.CairoFormat.contains(config.figureFormat)

--- a/src/main/scala/org/allenai/pdffigures2/SectionTitleExtractor.scala
+++ b/src/main/scala/org/allenai/pdffigures2/SectionTitleExtractor.scala
@@ -25,10 +25,11 @@ object SectionTitleExtractor extends Logging {
       false
     } else {
       val firstWordText = line.words.head.text
-      NumberRegex.pattern.matcher(firstWordText).matches() ||
-        RomanNumeralsRegex.pattern.matcher(firstWordText).matches() ||
-        LetterNumberRegex.pattern.matcher(firstWordText).matches() ||
-        AppendixRegex.pattern.matcher(firstWordText).matches()
+
+      RegexWithTimeout.matcher(NumberRegex.pattern, firstWordText).matches() ||
+      RegexWithTimeout.matcher(RomanNumeralsRegex.pattern, firstWordText).matches() ||
+      RegexWithTimeout.matcher(LetterNumberRegex.pattern, firstWordText).matches() ||
+      RegexWithTimeout.matcher(AppendixRegex.pattern, firstWordText).matches()
     }
   }
 


### PR DESCRIPTION
The main fix here is for a memory issue for papers that have a lot of connected black pixels. There is also a fix to use a regex variant that times out if matching takes too long.