### PR TITLE
Add pdfbox dependencies for reading image formats

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,6 +81,8 @@ libraryDependencies ++= Seq(
 
   // So PDFBox can parse more image formats
   "com.github.jai-imageio" % "jai-imageio-core" % "1.2.1",
+  "com.github.jai-imageio" % "jai-imageio-jpeg2000" % "1.3.0", // For handling jpeg2000 images
+  "com.levigo.jbig2" % "levigo-jbig2-imageio" % "1.6.5", // For handling jbig2 images
 
   // So PDFBox can parse security enabled but still readable PDFs
   "org.bouncycastle" % "bcprov-jdk15on" % "1.54",


### PR DESCRIPTION
This allows us to read jpeg2000 and jbig2 images. Originally added [here](https://github.com/allenai/scholar/pull/3405/files), but looks like it never got added to this repo.