### PR TITLE
Fix EXIT_ON_CLOSE field access error in Java9

### DIFF
--- a/src/main/scala/org/allenai/pdffigures2/VisualLogger.scala
+++ b/src/main/scala/org/allenai/pdffigures2/VisualLogger.scala
@@ -170,7 +170,7 @@ class VisualLogger(
       val panel = new JPanel(new BorderLayout())
       panel.add(visualization, BorderLayout.CENTER)
       val frame = new JFrame()
-      frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE)
+      frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE)
       frame.add(panel)
 
       // So our frame can be closed by hot key, on OSX this means at least Cmd-W works


### PR DESCRIPTION
- Replace JFrame with WindowConstants
- Java bug : https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8073420
- Scala issue :  https://github.com/scala/bug/issues/10596