### PR TITLE
fix for cairo to render to EPS / PDF

### DIFF
--- a/src/main/scala/org/allenai/pdffigures2/FigureExtractorBatchCli.scala
+++ b/src/main/scala/org/allenai/pdffigures2/FigureExtractorBatchCli.scala
@@ -190,7 +190,7 @@ object FigureExtractorBatchCli extends Logging {
             )
             val savedFigures = FigureRenderer
               .saveFiguresAsImagesCairo(
-                doc,
+                inputFile,
                 filenames.zip(document.figures),
                 config.figureFormat,
                 config.dpi
@@ -228,7 +228,7 @@ object FigureExtractorBatchCli extends Logging {
             )
             val savedFigures = FigureRenderer
               .saveFiguresAsImagesCairo(
-                doc,
+                inputFile,
                 filenames.zip(figuresWithErrors.figures),
                 config.figureFormat,
                 config.dpi


### PR DESCRIPTION
I kept getting IO Pipe errors when trying to stream the data over the pipe. I figured the original PDF file is on the filesystem already and just referencing it with the page numbers is probably more reliable with minimal additional overhead.

Also the paper width and paper height options were incompatible with EPS and since this is vectored anyway, probably is not necessary. 