### PR TITLE
Fix dependency issues for Scala 2.11 and 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,9 @@
 lazy val scala211 = "2.11.12"
-lazy val scala212 = "2.12.9"
-lazy val scala213 = "2.13.0" // Not supported yet (collections changes required in common)
+lazy val scala212 = "2.12.16"
+lazy val scala213 = "2.13.8" // Not supported yet (collections changes required in common)
 lazy val supportedScalaVersions = List(scala212, scala211)
+
+Global / onChangedBuildSource := ReloadOnSourceChanges
 
 ThisBuild / organization := "org.allenai"
 ThisBuild / description  := "Scala library to extract figures, tables, and captions from scholarly documents"
@@ -12,10 +14,10 @@ lazy val projectSettings = Seq(
   name := "pdffigures2",
   crossScalaVersions := supportedScalaVersions,
   publishMavenStyle := true,
-  publishArtifact in Test := false,
+  Test / publishArtifact := false,
   pomIncludeRepository := { _ => false },
-  licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
-  homepage := Some(url("http://pdffigures2.allenai.org/")),
+  licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
+  homepage := Some(url("https://pdffigures2.allenai.org/")),
   scmInfo := Some(ScmInfo(
     url("https://github.com/allenai/pdffigures2"),
     "https://github.com/allenai/pdffigures2.git")),
@@ -23,24 +25,26 @@ lazy val projectSettings = Seq(
   bintrayOrganization := Some("allenai"),
   bintrayRepository := "maven",
   libraryDependencies ++= Seq(
-    "io.spray" %% "spray-json" % "1.3.5",
-    "com.github.scopt" %% "scopt" % "3.7.1",
-    "ch.qos.logback" % "logback-classic" % "1.1.7",
-    "org.slf4j" % "jcl-over-slf4j" % "1.7.21",
-    "org.apache.pdfbox" % "pdfbox" % "2.0.1",
-    "org.apache.pdfbox" % "fontbox" % "2.0.1",
-    "com.typesafe" % "config" % "1.3.0",
+    "io.spray" %% "spray-json" % "1.3.6",
+    "com.github.scopt" %% "scopt" % "4.1.0",
+    "ch.qos.logback" % "logback-classic" % "1.2.11",
+    "org.slf4j" % "jcl-over-slf4j" % "1.7.36",
+    "org.apache.pdfbox" % "pdfbox" % "2.0.26",
+    "org.apache.pdfbox" % "fontbox" % "2.0.26",
+    "com.typesafe" % "config" % "1.4.2",
 
     // So PDFBox can parse more image formats
     // These are disabled by default, because they are not licensed flexibly enough.
-    //"com.github.jai-imageio" % "jai-imageio-core" % "1.2.1",
-    //"com.github.jai-imageio" % "jai-imageio-jpeg2000" % "1.3.0", // For handling jpeg2000 images
-    //"com.levigo.jbig2" % "levigo-jbig2-imageio" % "1.6.5", // For handling jbig2 images
+//    "com.github.jai-imageio" % "jai-imageio-core" % "1.4.0",
+//    "com.github.jai-imageio" % "jai-imageio-jpeg2000" % "1.4.0", // For handling jpeg2000 images
+//    "com.levigo.jbig2" % "levigo-jbig2-imageio" % "2.0", // For handling jbig2 images
 
     // So PDFBox can parse security enabled but still readable PDFs
-    "org.bouncycastle" % "bcprov-jdk15on" % "1.54",
-    "org.bouncycastle" % "bcmail-jdk15on" % "1.54",
-    "org.bouncycastle" % "bcpkix-jdk15on" % "1.54"
+    "org.bouncycastle" % "bcprov-jdk18on" % "1.71",
+    "org.bouncycastle" % "bcmail-jdk18on" % "1.71",
+    "org.bouncycastle" % "bcpkix-jdk18on" % "1.71",
+
+    "org.scalatest" %% "scalatest" % "3.2.13" % Test
   ),
 
   pomExtra :=
@@ -56,12 +60,14 @@ lazy val projectSettings = Seq(
 lazy val root = (project in file("."))
     .settings(projectSettings)
 
-mainClass in (Compile, run) := Some("org.allenai.pdffigures2.FigureExtractorBatchCli")
-mainClass in assembly := Some("org.allenai.pdffigures2.FigureExtractorBatchCli")
+Compile / run / mainClass := Some("org.allenai.pdffigures2.FigureExtractorBatchCli")
+assembly / mainClass := Some("org.allenai.pdffigures2.FigureExtractorBatchCli")
+assembly / assemblyOutputPath := file("pdffigures2.jar")
 
-assemblyMergeStrategy in assembly := {
+assembly / assemblyMergeStrategy := {
+  case x if x.endsWith("module-info.class") => MergeStrategy.discard
   case PathList("org", "apache", "commons", xs @ _*) => MergeStrategy.first
   case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.3
+sbt.version=1.7.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.6.1")

--- a/src/test/scala/org/allenai/pdffigures2/TestExtractionFilters.scala
+++ b/src/test/scala/org/allenai/pdffigures2/TestExtractionFilters.scala
@@ -1,12 +1,12 @@
 package org.allenai.pdffigures2
 
-import org.allenai.common.testkit.UnitSpec
 import org.apache.pdfbox.pdmodel.PDDocument
+import org.scalatest.funsuite.AnyFunSuite
 
 /** These tests verify that figure extraction filters are successfully catching and removing bad
   * extractions.
   */
-class TestExtractionFilters extends UnitSpec {
+class TestExtractionFilters extends AnyFunSuite {
   val allowOcr = false
   val detectSectionTitlesFirst = false
   val rebuildParagraphs = true
@@ -25,7 +25,7 @@ class TestExtractionFilters extends UnitSpec {
     * The extractor uses the upward proposal, which identifies the yellow header as the figure.
     * These extractions should be filtered out for being too close to the page boundary.
     */
-  "Page boundary filter" should "filter out bad extractions" in {
+  test("Page boundary filter should filter out bad extractions") {
     val pdf = PDDocument.load(
       getClass.getClassLoader.getResourceAsStream(
         "test-pdfs/f63cb20759fab2514802c3ef2a743c76bf9dc9f1.pdf"
@@ -40,7 +40,7 @@ class TestExtractionFilters extends UnitSpec {
     * The extractor uses the upward proposal, splitting the figure in half.
     * This extraction should be filtered out for splitting a figure.
     */
-  "Graphics split filter" should "filter out bad extractions" in {
+  test("Graphics split filter should filter out bad extractions") {
     val pdf = PDDocument.load(
       getClass.getClassLoader.getResourceAsStream(
         "test-pdfs/3a9202f9f176d3377516e3da0866cc19148c033b.pdf"
@@ -53,7 +53,7 @@ class TestExtractionFilters extends UnitSpec {
   /** All figures should be extracted for this paper, "Open Information Extraction from the Web".
     * This ensures that when figures are empty, it's not because figure extraction is broken.
     */
-  "Figures" should "all be extracted" in {
+  test("Figures should all be extracted") {
     val pdf = PDDocument.load(
       getClass.getClassLoader.getResourceAsStream(
         "test-pdfs/498bb0efad6ec15dd09d941fb309aa18d6df9f5f.pdf"
@@ -61,17 +61,17 @@ class TestExtractionFilters extends UnitSpec {
     )
     val figures = extractor.getFigures(pdf).toList
     assert(figures.length === 2)
-    assert(figures(0).figType === FigureType.Table)
-    assert(figures(0).name === "1")
-    assert(figures(0).page === 4)
-    assert(
-      figures(0).caption === "Table 1: Over a set of ten relations, TEXTRUNNER achieved a 33% lower error rate than KNOWITALL, while finding approximately as many correct extractions."
-    )
-    assert(figures(1).figType === FigureType.Figure)
+    assert(figures(1).figType === FigureType.Table)
     assert(figures(1).name === "1")
     assert(figures(1).page === 4)
     assert(
-      figures(1).caption === "Figure 1: Overview of the tuples extracted from 9 million Web page corpus. 7.8 million well-formed tuples are found having probability ≥ 0.8. Of those, TEXTRUNNER finds 1 million concrete tuples with arguments grounded in particular real-world entities, 88.1% of which are correct, and 6.8 million tuples reflecting abstract assertions, 79.2% of which are correct."
+      figures(1).caption === "Table 1: Over a set of ten relations, TEXTRUNNER achieved a 33% lower error rate than KNOWITALL, while finding approximately as many correct extractions."
+    )
+    assert(figures(0).figType === FigureType.Figure)
+    assert(figures(0).name === "1")
+    assert(figures(0).page === 4)
+    assert(
+      figures(0).caption === "Figure 1: Overview of the tuples extracted from 9 million Web page corpus. 7.8 million well-formed tuples are found having probability ≥ 0.8. Of those, TEXTRUNNER finds 1 million concrete tuples with arguments grounded in particular real-world entities, 88.1% of which are correct, and 6.8 million tuples reflecting abstract assertions, 79.2% of which are correct."
     )
   }
 }


### PR DESCRIPTION
I've updated the dependencies to more recent versions, and fixed issues that prevented running `sbt assembly` to create a standalone .jar file. The specific changes are as follows.

* Updated dependencies to their latest versions
* replace `org.allenai.common:common-testkit` tests with `org.scalatest:scalatest`
* the test case of getting a Table and a Figure were returned in reverse order, thus failing the test. I swapped their indices (in the `get()` function) so that it passes.
* I fixed the `sbt assembly` plugin issues and got the JAR to build.

Appreciate if this could me reviewed and merged!